### PR TITLE
adding gif to 11ty passthrough mapping

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -22,6 +22,7 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addPassthroughCopy("src/**/*.eps");
   eleventyConfig.addPassthroughCopy("src/**/*.jpg");
   eleventyConfig.addPassthroughCopy("src/**/*.png");
+  eleventyConfig.addPassthroughCopy("src/**/*.gif");
   eleventyConfig.addPassthroughCopy("src/**/*.pdf");
   eleventyConfig.addPassthroughCopy("src/**/*.svg");
   eleventyConfig.addPassthroughCopy("src/**/*.var");


### PR DESCRIPTION
We weren't able to publish the TEI badges in gif format, so I updated the 11ty passthrough mapping to all .gif to be published.