### PR TITLE
Dockerize the website for production

### DIFF
--- a/.docker/conf/httpd.conf
+++ b/.docker/conf/httpd.conf
@@ -193,7 +193,7 @@ LoadModule negotiation_module modules/mod_negotiation.so
 LoadModule dir_module modules/mod_dir.so
 #LoadModule imagemap_module modules/mod_imagemap.so
 #LoadModule actions_module modules/mod_actions.so
-#LoadModule speling_module modules/mod_speling.so
+LoadModule speling_module modules/mod_speling.so
 #LoadModule userdir_module modules/mod_userdir.so
 LoadModule alias_module modules/mod_alias.so
 #LoadModule rewrite_module modules/mod_rewrite.so
@@ -552,3 +552,7 @@ SSLRandomSeed startup builtin
 SSLRandomSeed connect builtin
 </IfModule>
 
+<IfModule mod_speling.c>
+  CheckSpelling On
+  CheckCaseOnly On
+</IfModule>

--- a/.docker/conf/httpd.conf
+++ b/.docker/conf/httpd.conf
@@ -298,6 +298,11 @@ DocumentRoot "/usr/local/apache2/htdocs"
     
 </Directory>
 
+#
+# CORS settings for the TEI Guidelines at https://www.tei-c.org/release/
+# This directory is *not* part of the website repo
+# but will be mounted on the production system from the Vault
+#
 <Directory "/usr/local/apache2/htdocs/release">
     Options Indexes FollowSymLinks
     Require all granted
@@ -307,6 +312,11 @@ DocumentRoot "/usr/local/apache2/htdocs"
     Header set Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type"
 </Directory>
 
+#
+# CORS settings for the TEI Vault at https://www.tei-c.org/Vault
+# This directory is *not* part of the website repo
+# but will be mounted on the production system from the Vault
+#
 <Directory "/usr/local/apache2/htdocs/Vault">
     Options Indexes FollowSymLinks
     Require all granted

--- a/.docker/conf/httpd.conf
+++ b/.docker/conf/httpd.conf
@@ -229,7 +229,7 @@ Group www-data
 # e-mailed.  This address appears on some server-generated pages, such
 # as error documents.  e.g. admin@your-domain.com
 #
-ServerAdmin you@example.com
+ServerAdmin web@tei-c.org
 
 #
 # ServerName gives the name and port that the server uses to identify itself.
@@ -296,6 +296,24 @@ DocumentRoot "/usr/local/apache2/htdocs"
     #
     Require all granted
     
+</Directory>
+
+<Directory "/usr/local/apache2/htdocs/release">
+    Options Indexes FollowSymLinks
+    Require all granted
+    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Credentials "true"
+    Header set Access-Control-Allow-Methods "GET, POST, OPTIONS"
+    Header set Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type"
+</Directory>
+
+<Directory "/usr/local/apache2/htdocs/Vault">
+    Options Indexes FollowSymLinks
+    Require all granted
+    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Credentials "true"
+    Header set Access-Control-Allow-Methods "GET, POST, OPTIONS"
+    Header set Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type"
 </Directory>
 
 #

--- a/.docker/conf/httpd.conf
+++ b/.docker/conf/httpd.conf
@@ -276,6 +276,10 @@ DocumentRoot "/usr/local/apache2/htdocs"
     # http://httpd.apache.org/docs/2.4/mod/core.html#options
     # for more information.
     #
+    # Set English as fallback for other languages than Spanish
+    LanguagePriority en es
+    ForceLanguagePriority Prefer Fallback
+
     Options FollowSymLinks MultiViews
     AddHandler type-map var
     DirectoryIndex index.var index.html

--- a/.docker/conf/httpd.conf
+++ b/.docker/conf/httpd.conf
@@ -280,7 +280,7 @@ DocumentRoot "/usr/local/apache2/htdocs"
     LanguagePriority en es
     ForceLanguagePriority Prefer Fallback
 
-    Options FollowSymLinks MultiViews
+    Options Indexes FollowSymLinks MultiViews
     AddHandler type-map var
     DirectoryIndex index.var index.html
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 dist
 node_modules
+.idea/
+.github/
+.git/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,13 @@ on:
   push:
     branches:
       - main
+      - dockerize
     paths:
       - "src/**"
       - "package.json"
       - "package-lock.json"
+      - "Dockerfile"
+      - ".docker/**"
   repository_dispatch:
     types: [update-documentation]
 jobs:
@@ -14,26 +17,50 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
           submodules: 'recursive'
       - name: Update submodule
         run: git submodule update --remote src/documentation/Documentation
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+
+      # Login to DockerHub registry
+      - name: Log in to DockerHub
+        uses: docker/login-action@v4
         with:
-          node-version: '23'
+          username: ${{ secrets.PETERS_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.PETERS_DOCKERHUB_TOKEN }}
+
+      # Login to dh.io registry
+      - name: Log in to DockerHub
+        uses: docker/login-action@v4
+        with:
+          registry: dhi.io
+          username: ${{ secrets.PETERS_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.PETERS_DOCKERHUB_TOKEN }}
+
       - name: Set up analytics
         run: cp src/_includes/analytics.html_src src/_includes/analytics.html
-      - name: Build
-        run: |
-          npm install
-          npx @11ty/eleventy
-      - name: Deploy
-        uses: webfactory/ssh-agent@v0.9.0
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
         with:
-          ssh-private-key: ${{ secrets.TEIWEB_KEY }}
-      - run: |
-          ssh -o StrictHostKeyChecking=accept-new ${{ secrets.TEIWEB_USER }}@${{ secrets.TEIWEB_HOST }} uptime
-          rsync -avz -e ssh --delete dist/ ${{ secrets.TEIWEB_USER }}@${{ secrets.TEIWEB_HOST }}:${{ secrets.TEIWEB_PATH }}
+          images: |
+            teic/website
+          flavor: |
+            latest=${{ github.ref == 'refs/heads/main' }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_IMAGE=dhi.io/httpd:2.4-debian

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Log in to DockerHub
         uses: docker/login-action@v4
         with:
+          # username and password are set in GitHub secrets
           username: ${{ secrets.PETERS_DOCKERHUB_USERNAME }}
           password: ${{ secrets.PETERS_DOCKERHUB_TOKEN }}
 
@@ -35,6 +36,7 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: dhi.io
+          # username and password are set in GitHub secrets
           username: ${{ secrets.PETERS_DOCKERHUB_USERNAME }}
           password: ${{ secrets.PETERS_DOCKERHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - dockerize
     paths:
       - "src/**"
       - "package.json"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,9 +38,6 @@ jobs:
           username: ${{ secrets.PETERS_DOCKERHUB_USERNAME }}
           password: ${{ secrets.PETERS_DOCKERHUB_TOKEN }}
 
-      - name: Set up analytics
-        run: cp src/_includes/analytics.html_src src/_includes/analytics.html
-
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Default base image is nginx:alpine
+# while a hardened image can be requested
+# by providing the build argument BASE_IMAGE="dhi.io/httpd:2.4-debian"
+# NB, you need to be loged in to DockerHub to download this image
+ARG BASE_IMAGE="httpd:2.4"
+
+# Step 1:
+# Build the webpages via eleventy
+FROM node:23 AS builder
+LABEL authors="pstadler"
+
+WORKDIR /app
+
+COPY . .
+
+RUN cp src/_includes/analytics.html_src src/_includes/analytics.html && \
+    npm ci && \
+    npx @11ty/eleventy
+
+# Step 2:
+# Build the web server
+FROM $BASE_IMAGE
+
+LABEL org.opencontainers.image.authors="Peter Stadler for the TEI Consortium"
+LABEL org.opencontainers.image.source="https://github.com/TEIC/website"
+
+RUN rm -rf usr/local/apache2/htdocs/*
+
+COPY --from=builder /app/dist/ /usr/local/apache2/htdocs/
+COPY .docker/conf/httpd.conf /usr/local/apache2/conf/


### PR DESCRIPTION
The goal of this PR is to provide a Dockerfile and a pipeline for building a Docker image from this repository that can be used in production at tei-c.org.
It includes a new multi-stage `Dockerfile`, enhancements to the GitHub Actions workflow for building and pushing Docker images, and updates to the Apache configuration to support content negotiation and spelling correction. It also refines the `.dockerignore` file for cleaner builds.

**Dockerization and CI/CD improvements:**

* Added a multi-stage `Dockerfile` that builds the site with Eleventy and serves it using a configurable Apache (`httpd`) base image, supporting both default and hardened images via the `BASE_IMAGE` build argument.
* Overhauled the GitHub Actions workflow (`.github/workflows/build.yml`) to build and push Docker images. The workflow now also triggers on changes to Docker-related files.

**Apache server enhancements:**

* Enabled the `mod_speling` module and configured it to correct minor spelling errors in URLs, improving user experience. 
* Enhanced content negotiation in `httpd.conf` by setting English as the fallback language and improving directory listing options.