### PR TITLE
remove romaantiqua link from top nav

### DIFF
--- a/src/_data/menus.json
+++ b/src/_data/menus.json
@@ -162,10 +162,6 @@
           "url": "https://roma.tei-c.org"
         },
         {
-          "name": "Roma Antiqua",
-          "url": "https://romaantiqua.tei-c.org"
-        },
-        {
           "name": "Stylesheets",
           "url": "https://github.com/TEIC/Stylesheets"
         },
@@ -184,10 +180,6 @@
         {
           "name": "Roma",
           "url": "https://roma.tei-c.org"
-        },
-        {
-          "name": "Roma Antiqua",
-          "url": "https://romaantiqua.tei-c.org"
         },
         {
           "name": "Stylesheets",


### PR DESCRIPTION
This PR removes the link to "Roma Antiqua" from the top nav as discussed at our last infrastructure group meeting.